### PR TITLE
chore: fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ go test -cover ./...
 For complete API documentation, see:
 
 - [USPS Addresses API Documentation](https://developers.usps.com/addressesv3)
-- [USPS OAuth 2.0 API Documentation](https://developers.usps.com/Oauth)
+- [USPS OAuth 2.0 API Documentation](https://developers.usps.com/oauth)
 
 ## License
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the USPS OAuth 2.0 API documentation URL to the current endpoint so links in the API Documentation section resolve to the correct OAuth docs. This ensures easier access to the latest integration guidance and reduces confusion when following authentication setup steps or troubleshooting OAuth-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->