### PR TITLE
Clamp OAuth token expiration when refresh buffer exceeds TTL

### DIFF
--- a/oauth_token_provider.go
+++ b/oauth_token_provider.go
@@ -31,7 +31,7 @@ type OAuthTokenProvider struct {
 	useRefreshTokens bool
 }
 
-// OAuthTokenOption is a functional option for configuring OAuthTokenProvider
+// OAuthTokenOption is a functional option for configuring OAuthTokenProvider.
 type OAuthTokenOption func(*OAuthTokenProvider)
 
 // WithOAuthScopes sets the OAuth scopes for token requests.
@@ -170,8 +170,23 @@ func (p *OAuthTokenProvider) GetToken(ctx context.Context) (string, error) {
 
 // calculateExpiration calculates the token expiration time with the configured refresh buffer.
 func (p *OAuthTokenProvider) calculateExpiration(expiresIn int) time.Time {
+	if expiresIn <= 0 {
+		// If the server does not provide a valid expiration, force an immediate refresh.
+		return time.Now()
+	}
+
 	expiresInDuration := time.Duration(expiresIn) * time.Second
-	return time.Now().Add(expiresInDuration - p.refreshBuffer)
+
+	buffer := p.refreshBuffer
+	if buffer >= expiresInDuration {
+		// Refresh at least one second before expiration when the buffer exceeds the token lifetime.
+		buffer = expiresInDuration - time.Second
+		if buffer < 0 {
+			buffer = 0
+		}
+	}
+
+	return time.Now().Add(expiresInDuration - buffer)
 }
 
 // acquireTokenLocked acquires a new token using client credentials.

--- a/oauth_token_provider_test.go
+++ b/oauth_token_provider_test.go
@@ -486,6 +486,38 @@ func TestOAuthTokenProvider_TokenExpirationCalculation(t *testing.T) {
 	}
 }
 
+func TestOAuthTokenProvider_TokenExpirationShortLifespan(t *testing.T) {
+	now := time.Now()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := models.ProviderAccessTokenResponse{
+			AccessToken: "short-lived-token",
+			ExpiresIn:   30,
+			TokenType:   "Bearer",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewOAuthTokenProvider(
+		"client-id",
+		"client-secret",
+		WithTokenRefreshBuffer(10*time.Minute),
+	)
+	provider.oauthClient = NewOAuthClient(WithBaseURL(server.URL))
+
+	if _, err := provider.GetToken(context.Background()); err != nil {
+		t.Fatalf("GetToken failed: %v", err)
+	}
+
+	expectedExpiration := now.Add(time.Second)
+	if provider.tokenExpiration.Before(expectedExpiration.Add(-2*time.Second)) ||
+		provider.tokenExpiration.After(expectedExpiration.Add(2*time.Second)) {
+		t.Errorf("Token expiration should clamp to near actual expiration. Expected around %v, got %v",
+			expectedExpiration, provider.tokenExpiration)
+	}
+}
+
 func TestOAuthTokenProvider_NoRefreshTokenWhenDisabled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Return a response with refresh token


### PR DESCRIPTION
## Summary
- clamp the OAuth token expiration calculation so refresh buffers longer than the token lifetime no longer push the cached token into the past
- treat non-positive expiration hints as immediately stale and document the OAuth token option comment period
- add regression coverage for short-lived tokens to ensure the cached expiration stays sane

## Testing
- go vet ./...
- go build ./...
- go test -v -cover ./...


------
https://chatgpt.com/codex/tasks/task_e_6907b3a8dd20832ba2e8f8d79c10d4bc