### PR TITLE
Fix normalizer classification of trailing directionals

### DIFF
--- a/parser/normalizer.go
+++ b/parser/normalizer.go
@@ -34,6 +34,10 @@ func (n *Normalizer) normalize(tokens []Token) ([]Token, []Diagnostic) {
 					// Might be post-directional
 					token.Type = TokenPostDirectional
 				}
+			} else {
+				// No following token means this directional trails the street segment
+				// and should be treated as a post-directional.
+				token.Type = TokenPostDirectional
 			}
 		}
 


### PR DESCRIPTION
## Summary
- treat trailing directional tokens as post-directionals during normalization
- ensure downstream parsing retains street post-directional data

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_69099ab009c8832b96035ac87aecf4d7